### PR TITLE
Add an ability to define different times according to the moving direction of the blinds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .DS_Store
 .env
 package-lock.json
+.idea

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ Add the accessory in `config.json` in your home directory inside `.homebridge`.
       "webhook_https": false,
       "webhook_https_keyfile": "/path/to/https.key",
       "webhook_https_certfile": "/path/to/https.crt",
-      "motion_time": 10000,
+      "motion_up_time": 11000,
+      "motion_down_time": 10000,
       "response_lag": 0,
       "trigger_stop_at_boundaries": false,
       "verbose": false
@@ -176,6 +177,18 @@ Ensure that the motion time is configured properly, even when `position_url` is 
 ---
 
 `motion_time` is the time, in milliseconds, for your blinds to move from up to down. This should only include the time the motor is running. Filming this with your phone to determine the time may be easier than trying to do it with a timer. **NOTE**: If you are performing multiple blind requests simultaneously and are getting network timeouts due to your configuration, try using non-identical `motion_time` (e.g., 9800, 10000, 10200 vs. 10000 for each) it may help.
+
+There are additional two configurations parameters, `motion_down_time` and `motion_up_time`.        
+
+`motion_down_time` is the time, in milliseconds, for your blinds to move from up to down. Everything else is exactly as described in `motion_time` above.
+
+`motion_up_time` is the time, in milliseconds, for your blinds to move from down to up. Everything else is exactly as described in `motion_time` above.
+
+The reason for this, is that there are some blinds that their opening time is different from closing time, due to simple physics - The weight of the shutter affects on the speed of the motor.  
+Ideally, a better approach would be using some kind of gradual equation for calculating the exact time, according to the position, because the weight gradually added or subtracted during the move. But, hopefully this will be a nice to have feature in the future.
+
+**Note!**  
+`motion_down_time` and `motion_up_time` are always have higher priority over `motion_time`. This means, that if all three explicitly provided in the configuration file, the value set in `motion_down_time` and `motion_up_time` will be used instead and the value in `motion_time` will be ignored. You can also provide only `motion_down_time` and `motion_up_time` value without providing `motion_time`. If only `motion_time` is provided, its value will be used for `motion_down_time` and `motion_up_time`.
 
 **Steps:**
 1. HTTP UP/DOWN request sent; wait for successful reply (i.e., `success_codes`) = `HTTP request delay (measured)`

--- a/README.md
+++ b/README.md
@@ -178,18 +178,17 @@ Ensure that the motion time is configured properly, even when `position_url` is 
 
 `motion_time` is the time, in milliseconds, for your blinds to move from up to down. This should only include the time the motor is running. Filming this with your phone to determine the time may be easier than trying to do it with a timer. **NOTE**: If you are performing multiple blind requests simultaneously and are getting network timeouts due to your configuration, try using non-identical `motion_time` (e.g., 9800, 10000, 10200 vs. 10000 for each) it may help.
 
-There are additional two configurations parameters, `motion_down_time` and `motion_up_time`.        
+**Note!**  
+For cases where `motion_time` varies based on the direction of shutter movement (i.e., due to gravity), `motion_down_time` and `motion_up_time` may be used for more fine-tuning.
 
-`motion_down_time` is the time, in milliseconds, for your blinds to move from up to down. Everything else is exactly as described in `motion_time` above.
+- `motion_down_time` is the time, in milliseconds, for your blinds to move from up to down.
+- `motion_up_time` is the time, in milliseconds, for your blinds to move from down to up.
+- Everything else is exactly as described in `motion_time` above.
 
-`motion_up_time` is the time, in milliseconds, for your blinds to move from down to up. Everything else is exactly as described in `motion_time` above.
-
-The reason for this, is that there are some blinds that their opening time is different from closing time, due to simple physics - The weight of the shutter affects on the speed of the motor.  
-Ideally, a better approach would be using some kind of gradual equation for calculating the exact time, according to the position, because the weight gradually added or subtracted during the move. But, hopefully this will be a nice to have feature in the future.
+Ideally, a better approach would be using some kind of equation for calculating the exact time. This would be a nice-to-have feature in the future.
 
 **Note!**  
-`motion_down_time` and `motion_up_time` are always have higher priority over `motion_time`. This means, that if all three explicitly provided in the configuration file, the value set in `motion_down_time` and `motion_up_time` will be used instead and the value in `motion_time` will be ignored. You can also provide only `motion_down_time` and `motion_up_time` value without providing `motion_time`. If only `motion_time` is provided, its value will be used for `motion_down_time` and `motion_up_time`.
-
+`motion_down_time` and `motion_up_time` have a higher priority over `motion_time`. This means, that if all three are explicitly provided in the configuration file, the value set in `motion_time` will be ignored.
 **Steps:**
 1. HTTP UP/DOWN request sent; wait for successful reply (i.e., `success_codes`) = `HTTP request delay (measured)`
 2. Wait for device to send the signal to blinds, and movement begins = `response_lag`

--- a/config.schema.json
+++ b/config.schema.json
@@ -70,6 +70,18 @@
 				"title": "Motion Time",
 				"type": "number",
 				"default": 10000,
+				"description": "Time (in ms) for blinds to move completely up or down."
+			},
+			"motion_up_time": {
+				"title": "Motion Upward Time",
+				"type": "number",
+				"default": 10000,
+				"description": "Time (in ms) for blinds to move completely from down to up."
+			},
+			"motion_down_time": {
+				"title": "Motion Downward Time",
+				"type": "number",
+				"default": 10000,
 				"description": "Time (in ms) for blinds to move completely from up to down."
 			},
 			"response_lag": {

--- a/index.js
+++ b/index.js
@@ -62,7 +62,9 @@ function BlindsHTTPAccessory(log, config) {
     this.showToggleButton = config.show_toggle_button === true;
 
     // motion time vars
-    this.motionTime = parseInt(config.motion_time, 10) || 10000;
+    const motionTimeConfig = parseInt(config.motion_time, 10) || 10000;
+    this.motionUpTime = parseInt(config.motion_up_time, 10) || motionTimeConfig;
+    this.motionDownTime = parseInt(config.motion_down_time, 10) || motionTimeConfig;
     this.responseLag = parseInt(config.response_lag, 10) || 0;
 
     // advanced vars
@@ -414,7 +416,8 @@ BlindsHTTPAccessory.prototype.setTargetPosition = function (pos, callback) {
             this.lastCommandMoveUp = moveUp;
 
             this.storage.setItemSync(this.name, this.currentTargetPosition);
-            const motionTimeStep = this.motionTime / 100;
+            const motionTime = moveUp ? this.motionUpTime : this.motionDownTime;
+            const motionTimeStep = motionTime / 100;
             const waitDelay = Math.abs(this.currentTargetPosition - this.lastPosition) * motionTimeStep;
 
             this.log.info(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-blinds",
-  "version": "1.3.20",
+  "version": "1.3.21",
   "description": "A homebridge plugin to control my blinds",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "author": "Daniel Caspi <dan@element26.net>",
   "contributors": [
     "Robin Temme <zwerch1337@googlemail.com>",
-    "Jimmy Henderickx <jimmyhdx@gmail.com>"
+    "Jimmy Henderickx <jimmyhdx@gmail.com>",
+    "Slavik Meltser <slavikme@gmail.com>"
   ],
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
Added additional two configuration parameters `motion_down_time` and `motion_up_time`.

The reason for this change, is that there are some blinds that their opening time is different from closing time, due to simple physics - The weight of the shutter affects on the speed of the motor.