### PR TITLE
Drop Node.js 18 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20, 22]
+        node: [20, 22]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -22,7 +22,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node: [18, 20, 22]
+                node: [20, 22]
                 homebridge: ['1', '2']
 
         steps:

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "automation"
     ],
     "engines": {
-        "node": "^18.20.0 || ^20.18.0 || ^22.10.0",
+        "node": "^20.18.0 || ^22.10.0",
         "homebridge": "^1.8.0 || ^2.0.0-beta.0"
     },
     "repository": {


### PR DESCRIPTION
This PR removes support for Node.js 18 across the project, updating CI/CD workflows and package configuration to require Node.js 20 or higher.

## Changes Made

- **CI/CD Workflows**: Updated both `ci.yml` and `smoke.yml` to remove Node.js 18 from the test matrix, now testing against Node.js 20 and 22 only
- **Package Configuration**: Updated `engines` field in `package.json` to require `^20.18.0 || ^22.10.0`, removing the `^18.20.0` constraint

## Rationale

Node.js 18 has reached end-of-life and is no longer actively maintained. This change aligns the project with current Node.js LTS versions and reduces the maintenance burden of supporting legacy versions.

https://claude.ai/code/session_01FjPiKpWVyspTe9sS4T8PGW