### PR TITLE
Add support for Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22]
+        node: [20, 22, 24]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -22,7 +22,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node: [20, 22]
+                node: [20, 22, 24]
                 homebridge: ['1', '2']
 
         steps:

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "automation"
     ],
     "engines": {
-        "node": "^20.18.0 || ^22.10.0",
+        "node": "^20.18.0 || ^22.10.0 || ^24.0.0",
         "homebridge": "^1.8.0 || ^2.0.0-beta.0"
     },
     "repository": {


### PR DESCRIPTION
## Summary
This PR adds support for Node.js 24 across the project's CI/CD pipelines and engine requirements.

## Key Changes
- Updated CI workflow to test against Node.js 20, 22, and 24
- Updated smoke test workflow to test against Node.js 20, 22, and 24
- Updated `package.json` engines field to explicitly support Node.js 24.x (`^24.0.0`)

## Details
The changes ensure the project is tested and compatible with the latest Node.js 24 release while maintaining backward compatibility with Node.js 20 and 22. This allows users running Node.js 24 to install and use this package without warnings about unsupported engine versions.

https://claude.ai/code/session_019dJuWWg7EuwH8s47aNmag6