### PR TITLE
chore: release 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 follows [Semantic Versioning](https://semver.org/).
 
+## [3.0.1] - 2026-05-13
+
+### Fixed
+
+- **Node 24 support** — `engines.node` now accepts Node 24 in addition
+  to 20 and 22. Previously, Homebridge refused to load the plugin on
+  Node 24 with `requires a Node.js version of ^20.18.0 || ^22.10.0`
+  ([#104](https://github.com/dxdc/homebridge-blinds/issues/104)). The
+  CI and smoke matrices also now exercise Node 24.
+
 ## [3.0.0] - 2026-05-10
 
 > **Drop-in upgrade.** Every working v2 configuration continues to work

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "homebridge-blinds",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "homebridge-blinds",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "funding": [
                 {
                     "type": "github",
@@ -2923,7 +2923,7 @@
             }
         },
         "node_modules/shebang-regex": {
-            "version": "3.0.0",
+            "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "homebridge-blinds",
     "displayName": "Blinds (HTTP)",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "description": "Homebridge plugin to control HTTP, REST, MQTT, shell-script and CLI-driven blinds, shades, awnings, shutters, and roller curtains in Apple HomeKit.",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
Bumps package version to match the v3.0.1 tag and adds a changelog entry documenting the Node 24 engine fix (#104).

https://claude.ai/code/session_019dJuWWg7EuwH8s47aNmag6