### PR TITLE
ci: consolidate Dependabot updates into batched groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,19 +6,34 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     groups:
-      typescript-eslint:
+      # Batch routine production dependency bumps (minor/patch) into one PR.
+      # Major bumps stay ungrouped so they get individual review.
+      production-dependencies:
+        applies-to: version-updates
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
         patterns:
-          - 'typescript-eslint'
-          - '@typescript-eslint/*'
-      vitest:
+          - '*'
+      # Batch routine development dependency bumps (minor/patch) into one PR.
+      development-dependencies:
+        applies-to: version-updates
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
         patterns:
-          - 'vitest'
-          - '@vitest/*'
-      types:
-        patterns:
-          - '@types/*'
+          - '*'
+    # Note: groups above only apply to version-updates, so security updates are
+    # intentionally left ungrouped and arrive as individual PRs to stand out.
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - '*'


### PR DESCRIPTION
## What

Tightens the Dependabot configuration so routine version bumps are batched instead of filing one PR per dependency, while keeping the updates that need human eyes individual.

### npm
- **`production-dependencies`** group — batches all production `minor`/`patch` bumps into a single PR.
- **`development-dependencies`** group — batches all development `minor`/`patch` bumps into a single PR.
- Both groups use `applies-to: version-updates`, so **security updates are intentionally left ungrouped** and arrive as their own individual PRs (easy to spot and fast-track).
- **Major** bumps stay ungrouped → individual PRs, since they typically need review.

### github-actions
- Groups all action updates into a single PR.

## Why

Dependabot had grown to ~8 simultaneous open PRs. With this config the routine churn collapses to ~2 npm PRs (prod + dev) plus 1 actions PR per week, while security fixes and majors remain visible on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HK1HYjrcMD5K2KCwnoRaUH)_