### PR TITLE
fix: pin @types/node to Node 20 floor, ignore major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    ignore:
+      # @types/node tracks the lowest supported Node engine (20.x); never bump major.
+      - dependency-name: '@types/node'
+        update-types:
+          - version-update:semver-major
     groups:
       # Batch routine production dependency bumps (minor/patch) into one PR.
       # Major bumps stay ungrouped so they get individual review.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
             },
             "devDependencies": {
                 "@eslint/js": "^10.0.1",
-                "@types/node": "^25.9.1",
+                "@types/node": "^20.19.43",
                 "eslint": "^10.3.0",
                 "homebridge": "^2.0.2",
                 "prettier": "^3.8.3",
@@ -749,9 +749,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -769,9 +766,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -789,9 +783,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -809,9 +800,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -829,9 +817,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -849,9 +834,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -996,13 +978,13 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.9.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-            "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+            "version": "20.19.43",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+            "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": ">=7.24.0 <7.24.7"
+                "undici-types": "~6.21.0"
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2265,9 +2247,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -2289,9 +2268,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -2313,9 +2289,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -2337,9 +2310,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -3195,9 +3165,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-            "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
             "dev": true,
             "license": "MIT"
         },

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     },
     "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@types/node": "^25.9.1",
+        "@types/node": "^20.19.43",
         "eslint": "^10.3.0",
         "homebridge": "^2.0.2",
         "prettier": "^3.8.3",


### PR DESCRIPTION
## What

Pins `@types/node` back to the **Node 20 floor** and stops Dependabot from bumping its major again.

- `@types/node`: `^25.9.1` → `^20.19.43`
- Adds a Dependabot `ignore` rule for `@types/node` `version-update:semver-major`

## Why

`engines.node` is `^20.18.0 || ^22.10.0 || ^24.0.0`, so the lowest supported runtime is **Node 20**. Dependabot had advanced `@types/node` to 25.x, which means type-checking against an API surface newer than the oldest runtime we ship on — code could compile locally yet fail at runtime on Node 20. Convention for a published library is to track `@types/node` to the lowest supported Node major.

## Verification

`typecheck`, `lint`, `test` (81 passing), and `build` all green locally with the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HK1HYjrcMD5K2KCwnoRaUH)_